### PR TITLE
Add handlers for mouseon and mouseout

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,35 @@ sets the time that the timeline should end. If `beginning` and `ending` are not 
 Takes in no arguments. Toggles the stacking/unstacking of data series in the timeline. Needs to be true in order for icons and labels to show up properly.
 
 ###.hover(callback)
-takes in a callback called on mouseover of the timeline data. Example
+takes in a callback called on mousemove of the timeline data. Example
 
 ```js
 d3.timeline()
   .hover(function (d, i, datum) { 
+    // d is the current rendering object
+    // i is the index during d3 rendering
+    // datum is the data object
+  });
+```
+
+###.mouseon(callback)
+takes in a callback called on mouseon of the timeline data. Example
+
+```js
+d3.timeline()
+  .mouseon(function (d, i, datum) {
+    // d is the current rendering object
+    // i is the index during d3 rendering
+    // datum is the data object
+  });
+```
+
+###.mouseout(callback)
+takes in a callback called on mouseout of the timeline data. Example
+
+```js
+d3.timeline()
+  .mouseout(function (d, i, datum) {
     // d is the current rendering object
     // i is the index during d3 rendering
     // datum is the data object

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -3,7 +3,9 @@
   d3.timeline = function() {
     var DISPLAY_TYPES = ["circle", "rect"];
 
-    var hover = function () {}, 
+    var hover = function () {},
+        mouseover = function () {},
+        mouseout = function () {},
         click = function () {},
         scroll = function () {},
         orient = "bottom",
@@ -105,6 +107,12 @@
             .style("fill", colorCycle(index))
             .on("mousemove", function (d, i) {
               hover(d, index, datum);
+            })
+            .on("mouseover", function (d, i) {
+              mouseover(d, i, datum);
+            })
+            .on("mouseout", function (d, i) {
+              mouseout(d, i, datum);
             })
             .on("click", function (d, i) {
               click(d, index, datum);
@@ -251,6 +259,18 @@
     timeline.hover = function (hoverFunc) {
       if (!arguments.length) return hover;
       hover = hoverFunc;
+      return timeline;
+    };
+
+    timeline.mouseover = function (mouseoverFunc) {
+      if (!arguments.length) return mouseoverFunc;
+      mouseover = mouseoverFunc;
+      return timeline;
+    };
+
+    timeline.mouseout = function (mouseoverFunc) {
+      if (!arguments.length) return mouseoverFunc;
+      mouseout = mouseoverFunc;
       return timeline;
     };
 


### PR DESCRIPTION
I'm using a (ToolTip)[http://jqueryui.com/tooltip/] to display information
about events when the user hovers their mouse above a timeline node. When the
mouse moves away from the node, I'd like the tooltip to go away. Currently
this is not possible with timeline.hover(), so I added handlers for the
mouseon and mouseout events.
