### PR TITLE
Added a new bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "d3-timeline",
+  "version": "0.0.1",
+  "main": "src/d3-timeline.js",
+  "ignore": [
+      "examples",
+      "lib",
+      ".bowerrc",
+      ".gitignore",
+      ".git",
+      ".jshintrc",
+      "bower.json",
+      "gruntfile.js",
+      "package.json",
+      "README.md"
+  ],
+  "dependencies": {
+    "d3": ">=3.4.3"
+  }
+}


### PR DESCRIPTION
I think it will be really interesting to have a bower package to implement this, and it's not really expensive.
The only thing missing after that is to register the package on bower `bower register d3-timeline git://github.com/jiahuang/d3-timeline.git` and create a 0.0.1 tag to make it easier to track `git tag -a v0.0.1 -m "release 0.0.1"`
