### PR TITLE
support numTicks in addition to time interval

### DIFF
--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -105,7 +105,7 @@
         .scale(xScale)
         .orient(orient)
         .tickFormat(tickFormat.format)
-        .ticks(tickFormat.tickTime, tickFormat.tickInterval)
+        .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
         .tickSize(tickFormat.tickSize);
 
       g.append("g")


### PR DESCRIPTION
d3 time scales don't currently support sub seconds intervals for estimating number of ticks. I found it useful to provide it as an override in tickFormat structure.
