### PR TITLE
allow click handler on the labels

### DIFF
--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -202,7 +202,10 @@
             gParent.append("text")
               .attr("class", "timeline-label")
               .attr("transform", "translate("+ 0 +","+ (itemHeight * 0.75 + margin.top + (itemHeight + itemMargin) * yAxisMapping[index])+")")
-              .text(hasLabel ? datum.label : datum.id);
+              .text(hasLabel ? datum.label : datum.id)
+              .on("click", function (d, i) {
+                click(d, index, datum);
+              });
           }
 
           if (typeof(datum.icon) !== "undefined") {


### PR DESCRIPTION
don't understand why clicking on the label of the line should not be allowed
