### PR TITLE
Remove bower.json from ignored files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
       ".gitignore",
       ".git",
       ".jshintrc",
-      "bower.json",
       "gruntfile.js",
       "package.json",
       "README.md"


### PR DESCRIPTION
The reason is, because resolvers (for example webpack) needs this info to find the main script.