### PR TITLE
Added property to turn time axis on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ d3.timeline()
   });
 ```
 ###.showTimeAxis(true | false)
-allows the axis to be turned off.  Defaults to true.
+Allows the axis to be turned off.  Defaults to true.
 
 ##License
 MIT

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ d3.timeline()
     // scale is the scale of the axis used
   });
 ```
+###.showTimeAxis(true | false)
+allows the axis to be turned off.  Defaults to true.
 
 ##License
 MIT

--- a/examples/example.html
+++ b/examples/example.html
@@ -79,7 +79,7 @@
 
       var width = 500;
       function timelineRect() {
-        var chart = d3.timeline();
+        var chart = d3.timeline().showTimeAxis(false);
 
         var svg = d3.select("#timeline1").append("svg").attr("width", width)
           .datum(testData).call(chart);
@@ -186,12 +186,12 @@
 
       timelineRect();
       timelineCircle();
-      timelineHover();
-      timelineStackedIcons();
-      timelineLabelColor();
-      timelineRotatedTicks();
-      timelineRectColors();
-      timelineRelativeTime();
+      //timelineHover();
+      //timelineStackedIcons();
+      //timelineLabelColor();
+      //timelineRotatedTicks();
+      //timelineRectColors();
+      //timelineRelativeTime();
     }
   </script>
 </head>

--- a/examples/example.html
+++ b/examples/example.html
@@ -30,7 +30,7 @@
       -o-transform: translate(0px,30px); /* Opera */
       -moz-transform: translate(0px,30px); /* Firefox */
     }
-
+    
     .coloredDiv {
       height:20px; width:20px; float:left;
     }
@@ -79,9 +79,16 @@
 
       var width = 500;
       function timelineRect() {
-        var chart = d3.timeline().showTimeAxis(false);
+        var chart = d3.timeline().showTimeAxis(true);
 
         var svg = d3.select("#timeline1").append("svg").attr("width", width)
+          .datum(testData).call(chart);
+      }
+      
+      function timelineRectNoAxis() {
+        var chart = d3.timeline().showTimeAxis(false);
+
+        var svg = d3.select("#timeline1_noaxis").append("svg").attr("width", width)
           .datum(testData).call(chart);
       }
 
@@ -185,13 +192,14 @@
       }
 
       timelineRect();
+      timelineRectNoAxis();
       timelineCircle();
-      //timelineHover();
-      //timelineStackedIcons();
-      //timelineLabelColor();
-      //timelineRotatedTicks();
-      //timelineRectColors();
-      //timelineRelativeTime();
+      timelineHover();
+      timelineStackedIcons();
+      timelineLabelColor();
+      timelineRotatedTicks();
+      timelineRectColors();
+      timelineRelativeTime();
     }
   </script>
 </head>
@@ -199,6 +207,10 @@
   <div>
     <h3>A simple timeline</h3>
     <div id="timeline1"></div>
+  </div>
+  <div>
+    <h3>A simple timeline without Axis</h3>
+    <div id="timeline1_noaxis"></div>
   </div>
   <div>
     <h3>It works with circles too</h3>

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -28,7 +28,6 @@
         timeIsRelative = false,
         itemHeight = 20,
         itemMargin = 5,
-        showTimeAxis = true;
         showTodayLine = false,
         showTodayFormat = {marginTop: 25, marginBottom: 0, width: 1, color: colorCycle},
         showBorderLine = false,
@@ -101,25 +100,22 @@
 
       var scaleFactor = (1/(ending - beginning)) * (width - margin.left - margin.right);
 
-      if (showTimeAxis) {
-        // draw the axis
-        var xScale = d3.time.scale()
-          .domain([beginning, ending])
-          .range([margin.left, width - margin.right]);
+      // draw the axis
+      var xScale = d3.time.scale()
+        .domain([beginning, ending])
+        .range([margin.left, width - margin.right]);
 
-        var xAxis = d3.svg.axis()
-          .scale(xScale)
-          .orient(orient)
-          .tickFormat(tickFormat.format)
-          .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
-          .tickSize(tickFormat.tickSize);
+      var xAxis = d3.svg.axis()
+        .scale(xScale)
+        .orient(orient)
+        .tickFormat(tickFormat.format)
+        .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
+        .tickSize(tickFormat.tickSize);
 
-        g.append("g")
-          .attr("class", "axis")
-          .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
-          .call(xAxis);
-      }
-      
+      g.append("g")
+        .attr("class", "axis")
+        .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
+        .call(xAxis);
 
       // draw the chart
       g.each(function(d, i) {

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -28,6 +28,7 @@
         timeIsRelative = false,
         itemHeight = 20,
         itemMargin = 5,
+        showTimeAxis = true;
         showTodayLine = false,
         showTodayFormat = {marginTop: 25, marginBottom: 0, width: 1, color: colorCycle},
         showBorderLine = false,
@@ -100,22 +101,25 @@
 
       var scaleFactor = (1/(ending - beginning)) * (width - margin.left - margin.right);
 
-      // draw the axis
-      var xScale = d3.time.scale()
-        .domain([beginning, ending])
-        .range([margin.left, width - margin.right]);
+      if (showTimeAxis) {
+        // draw the axis
+        var xScale = d3.time.scale()
+          .domain([beginning, ending])
+          .range([margin.left, width - margin.right]);
 
-      var xAxis = d3.svg.axis()
-        .scale(xScale)
-        .orient(orient)
-        .tickFormat(tickFormat.format)
-        .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
-        .tickSize(tickFormat.tickSize);
+        var xAxis = d3.svg.axis()
+          .scale(xScale)
+          .orient(orient)
+          .tickFormat(tickFormat.format)
+          .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
+          .tickSize(tickFormat.tickSize);
 
-      g.append("g")
-        .attr("class", "axis")
-        .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
-        .call(xAxis);
+        g.append("g")
+          .attr("class", "axis")
+          .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
+          .call(xAxis);
+      }
+      
 
       // draw the chart
       g.each(function(d, i) {

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -28,6 +28,7 @@
         timeIsRelative = false,
         itemHeight = 20,
         itemMargin = 5,
+        showTimeAxis = true,
         showTodayLine = false,
         showTodayFormat = {marginTop: 25, marginBottom: 0, width: 1, color: colorCycle},
         showBorderLine = false,
@@ -105,17 +106,20 @@
         .domain([beginning, ending])
         .range([margin.left, width - margin.right]);
 
-      var xAxis = d3.svg.axis()
-        .scale(xScale)
-        .orient(orient)
-        .tickFormat(tickFormat.format)
-        .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
-        .tickSize(tickFormat.tickSize);
+      if (showTimeAxis) {
+        var xAxis = d3.svg.axis()
+          .scale(xScale)
+          .orient(orient)
+          .tickFormat(tickFormat.format)
+          .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
+          .tickSize(tickFormat.tickSize);
 
-      g.append("g")
-        .attr("class", "axis")
-        .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
-        .call(xAxis);
+        g.append("g")
+          .attr("class", "axis")
+          .attr("transform", "translate(" + 0 +","+(margin.top + (itemHeight + itemMargin) * maxStack)+")")
+          .call(xAxis);  
+      }
+      
 
       // draw the chart
       g.each(function(d, i) {
@@ -487,6 +491,11 @@
     timeline.background = function (color) {
       if (!arguments.length) return backgroundColor;
       backgroundColor = color;
+      return timeline;
+    };
+
+    timeline.showTimeAxis = function (timeAxis) {
+      showTimeAxis = timeAxis;
       return timeline;
     };
 


### PR DESCRIPTION
I've cleaned up the commit, not sure why the README.md and example.html are showing full replaces, not much changed in each.

Property added is called showTimeAxis(true | false).  The property defaults to true to keep backwards compatibility.

Example of use:
```javascript
var chart = d3.timeline().showTimeAxis(false);
```

example.html was updated to show the original rectangle timeline without the axis.  Also updated README.md with usage.