### PR TITLE
Fix #64 Add tickValues as option to tickFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ look something like this:
 .labelFormat(function(label){ return label[currentLocale];})
 ```
 
-###.tickFormat({format: , tickTime: , tickInterval: , tickSize: })
+###.tickFormat({format: , tickTime: , tickInterval: , tickSize: , numTicks: , tickValues})
 sets the formatting of the ticks in the timeline. Defaults to
 ```js
 {
@@ -180,6 +180,11 @@ sets the formatting of the ticks in the timeline. Defaults to
   tickSize: 6
 }
 ```
+Tick interval/values can be set with:
+
+- ``tickTime`` and ``tickInterval``
+- ``numTicks`` and ``tickInterval``
+- ``tickValues``
 
 ###.rotateTicks(degrees)
 sets the degree of rotation of the tickmarks. Defaults to no rotation (0 degrees).

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -229,8 +229,13 @@
         .scale(xScale)
         .orient(orient)
         .tickFormat(tickFormat.format)
-        .ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval)
         .tickSize(tickFormat.tickSize);
+
+      if (tickFormat.tickValues !== null) {
+        xAxis.tickValues(tickFormat.tickValues);
+      } else {
+        xAxis.ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval);
+      }
 
       // draw the chart
       g.each(function(d, i) {

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -19,7 +19,9 @@
         tickFormat = { format: d3.time.format("%I %p"),
           tickTime: d3.time.hours,
           tickInterval: 1,
-          tickSize: 6 },
+          tickSize: 6,
+          tickValues: null
+        },
         colorCycle = d3.scale.category20(),
         colorPropertyName = null,
         display = "rect",
@@ -231,7 +233,7 @@
         .tickFormat(tickFormat.format)
         .tickSize(tickFormat.tickSize);
 
-      if (tickFormat.tickValues !== null) {
+      if (tickFormat.tickValues != null) {
         xAxis.tickValues(tickFormat.tickValues);
       } else {
         xAxis.ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval);


### PR DESCRIPTION
This basically calls [tickValues](https://github.com/mbostock/d3/wiki/SVG-Axes#tickValues) on the list supplied to tickFormat