### PR TITLE
Fix the case when stacked == false and no label

### DIFF
--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -333,7 +333,7 @@
           if (typeof(datum.icon) !== "undefined") {
             gParent.append("image")
               .attr("class", "timeline-label")
-              .attr("transform", "translate("+ 0 +","+ (margin.top + (itemHeight + itemMargin) * yAxisMapping[index])+")")
+              .attr("transform", "translate("+ 0 +","+ (margin.top + (itemHeight + itemMargin) * yAxisMapping[index] ? yAxisMapping[index] : 0)+")")
               .attr("xlink:href", datum.icon)
               .attr("width", margin.left)
               .attr("height", itemHeight);


### PR DESCRIPTION
The case when no label is defined by default I see this error:
Error: <text> attribute transform: Trailing garbage, "translate(0,NaN)".

Hope this commit will heal this case.