### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "d3-timeline",
   "version": "0.0.5",
   "main": "src/d3-timeline.js",
+  "license": "MIT",
   "ignore": [
       "examples",
       "lib",


### PR DESCRIPTION
Add the license type also to Bower metadata; this would allow me to deploy the library on webjars.org.