### PR TITLE
Support data points with ambiguous end-time

### DIFF
--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -260,7 +260,7 @@
             .attr("x", getXPos)
             .attr("y", getStackPosition)
             .attr("width", function (d, i) {
-              return (d.ending_time - d.starting_time) * scaleFactor;
+              return isNaN(parseFloat(d.ending_time - d.starting_time)) ? itemHeight : (d.ending_time - d.starting_time) * scaleFactor;
             })
             .attr("cy", function(d, i) {
                 return getStackPosition(d, i) + itemHeight/2;


### PR DESCRIPTION
Using 'display: circle;' and only specifying 'starting_time' results in 'width="NaN"' in SVG markup.

Might want to alternatively warn user to specify ending_time but for my uses this suffices. Should also cover any funky ending_time / starting_time values.