### PR TITLE
adds option to only tick at block start

### DIFF
--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -169,6 +169,19 @@
 
       setWidth();
 
+      var generateTicksFromBlocks = function() {
+        var ticks = []
+        g.each(function(d) {
+          for (var datum of d) {
+            for (var time of datum.times) {
+              ticks.push(new Date(time.starting_time))
+            }
+          }
+        })
+
+        return ticks
+      }
+
       // check if the user wants relative time
       // if so, substract the first timestamp from each subsequent timestamps
       if(timeIsRelative){
@@ -233,7 +246,9 @@
         .tickFormat(tickFormat.format)
         .tickSize(tickFormat.tickSize);
 
-      if (tickFormat.tickValues != null) {
+      if (tickFormat.atBlockStart) {
+        xAxis.tickValues(generateTicksFromBlocks())
+      } else if (tickFormat.tickValues != null) {
         xAxis.tickValues(tickFormat.tickValues);
       } else {
         xAxis.ticks(tickFormat.numTicks || tickFormat.tickTime, tickFormat.tickInterval);

--- a/src/d3-timeline.js
+++ b/src/d3-timeline.js
@@ -169,12 +169,32 @@
 
       setWidth();
 
-      var generateTicksFromBlocks = function() {
+      var generateTicksFromBlocks = function(overlap) {
         var ticks = []
         g.each(function(d) {
           for (var datum of d) {
             for (var time of datum.times) {
-              ticks.push(new Date(time.starting_time))
+              var current = new Date(time.starting_time)
+
+              if (!ticks.length) {
+                ticks.push(current)
+                continue
+              }
+
+              // check for overlap
+              if (overlap) {
+                var tickOverlaps = false
+                for (var tick of ticks) {
+                  if ((current >= tick && current - tick <= overlap)
+                      || (current < tick && tick - current <= overlap)) {
+                    tickOverlaps = true
+                  }
+                }
+
+                if (!tickOverlaps) ticks.push(current)
+              } else {
+                ticks.push(current)
+              }
             }
           }
         })
@@ -247,7 +267,7 @@
         .tickSize(tickFormat.tickSize);
 
       if (tickFormat.atBlockStart) {
-        xAxis.tickValues(generateTicksFromBlocks())
+        xAxis.tickValues(generateTicksFromBlocks(tickFormat.hideOverlapTicks))
       } else if (tickFormat.tickValues != null) {
         xAxis.tickValues(tickFormat.tickValues);
       } else {


### PR DESCRIPTION
Adds an option to solve the feature request in issue #102.

Use the new option `atBlockStart: true` as part of the `tickFormat` method.

Ex:

```
d3.timeline().tickFormat({ atBlockStart: true })
```

Also adds `hideOverlapTicks` options (which only works with `atBlockStart`).

`hideOverlapTicks` is an amount of ticks to not allow two timestamps to be drawn next to eachother and prevents two timestamps from overlapping.

Ex 1: `atBlockStart: true`:

![image](https://user-images.githubusercontent.com/2680142/45035969-e1e31d80-b020-11e8-8a0d-eadbe75cde38.png)

Ex 2: `atBlockStart: true, hideOperlapTicks 2700000` (45 min)

![image](https://user-images.githubusercontent.com/2680142/45036016-f8897480-b020-11e8-83d5-545e06344dc5.png)
